### PR TITLE
Fix test:dev command

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "dmitriiabramov/esfmt"
   },
   "scripts": {
-    "test:dev": "./node_modules/eslint/bin/eslint.js . && ./node_modules/mocha/bin/mocha --compilers js:babel/register test/**/*_test.js",
+    "test:dev": "./node_modules/eslint/bin/eslint.js . && ./node_modules/mocha/bin/_mocha test/setup.js test/**/*_test.js",
     "test:watch": "./node_modules/mocha/bin/mocha --compilers js:babel/register test/**/*_test.js --watch",
     "test": "./node_modules/eslint/bin/eslint.js . && ./node_modules/mocha/bin/_mocha test/setup.js test/**/*_test.js && cat ./coverage/coverage-final.json | ./node_modules/codecov.io/bin/codecov.io.js"
   },


### PR DESCRIPTION
```
➜  esfmt git:(master) npm run test:dev

> esfmt@0.0.14 test:dev /Users/mderbin/code/esfmt
> ./node_modules/eslint/bin/eslint.js . && ./node_modules/mocha/bin/mocha --compilers js:babel/register test/**/*_test.js

/Users/mderbin/code/esfmt/node_modules/babel-polyfill/lib/index.js:8
  throw new Error("only one instance of babel-polyfill is allowed");
        ^
Error: only one instance of babel-polyfill is allowed
```